### PR TITLE
Make require an optional field in release model

### DIFF
--- a/src/apps/models.py
+++ b/src/apps/models.py
@@ -69,7 +69,7 @@ class App(models.Model):
 class Release(models.Model):
     app = models.ForeignKey(App)
     version = models.CharField(max_length=31)
-    require = models.ForeignKey(NsRelease)
+    require = models.ForeignKey(NsRelease, null=True)
     date = models.DateField(default=datetime.now, blank=True)
     notes = MarkdownxField()
     filename = models.FileField(upload_to='release_files/', blank=True, null=True)


### PR DESCRIPTION
* Some Apps do not have an ns-3 release requirement as they work off `ns-3-dev`. Make the require field optional so that these Apps can be added to the DB properly.